### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
             - uses: actions/checkout@master
             - name: Publish to registry
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   registry: docker.pkg.github.com
                   name: docker.pkg.github.com/wavilikhin/nest-api/nest-api


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore